### PR TITLE
Add Express Polly proxy and update StoryPlayer audio handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# KidCoachAI
+
+This project provides a React client and an accompanying Node/Express backend that proxies requests to Amazon Polly.
+
+## Prerequisites
+
+Set the following environment variables before starting the backend service:
+
+- `AWS_ACCESS_KEY_ID`
+- `AWS_SECRET_ACCESS_KEY`
+- `AWS_REGION` (defaults to `us-east-1` if not provided)
+
+These credentials must have permission to call the Polly `SynthesizeSpeech` API.
+
+## Running the Backend
+
+```bash
+cd server
+npm install
+npm start
+```
+
+By default the server listens on port `5000` and exposes a `POST /api/polly` endpoint that returns a Base64-encoded audio stream.
+
+## Running the Client
+
+```bash
+cd client
+npm install
+npm start
+```
+
+The client expects the backend to be running on the same origin (e.g., by proxying during development) so that it can call `/api/polly` to synthesize speech.

--- a/client/src/components/StoryPlayer.js
+++ b/client/src/components/StoryPlayer.js
@@ -1,18 +1,10 @@
 import React, { useState, useEffect } from 'react';
-import AWS from 'aws-sdk';
-
-AWS.config.update({
-  accessKeyId: 'YOUR_ACCESS_KEY_ID',
-  secretAccessKey: 'YOUR_SECRET_ACCESS_KEY',
-  region: 'us-east-1'
-});
-
-const Polly = new AWS.Polly();
 
 const StoryPlayer = ({ story }) => {
   const [text, setText] = useState('');
   const [isPlaying, setIsPlaying] = useState(false);
   const [audio, setAudio] = useState(null);
+  const [error, setError] = useState(null);
 
   useEffect(() => {
     if (story) {
@@ -28,8 +20,16 @@ const StoryPlayer = ({ story }) => {
       setIsPlaying(false);
     } else {
       if (audio) {
-        audio.play();
-        setIsPlaying(true);
+        audio.play()
+          .then(() => {
+            setIsPlaying(true);
+            setError(null);
+          })
+          .catch((playError) => {
+            console.error(playError);
+            setError(playError.message);
+            setIsPlaying(false);
+          });
       } else if (text) {
         synthesizeSpeech(text);
       }
@@ -37,29 +37,76 @@ const StoryPlayer = ({ story }) => {
   };
 
   const synthesizeSpeech = (text) => {
-    const params = {
-      Text: text,
-      OutputFormat: 'mp3',
-      VoiceId: 'Joanna'
-    };
+    setError(null);
 
-    Polly.synthesizeSpeech(params, (err, data) => {
-      if (err) {
-        console.log(err, err.stack);
-      } else {
-        const uInt8Array = new Uint8Array(data.AudioStream);
-        const blob = new Blob([uInt8Array.buffer], { type: 'audio/mpeg' });
+    fetch('/api/polly', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ text })
+    })
+      .then(async (response) => {
+        const raw = await response.text();
+
+        if (!response.ok) {
+          try {
+            const data = JSON.parse(raw);
+            if (data && data.error) {
+              throw new Error(data.error);
+            }
+          } catch (parseError) {
+            if (raw) {
+              throw new Error(raw);
+            }
+          }
+
+          throw new Error('Failed to synthesize speech');
+        }
+
+        try {
+          return JSON.parse(raw);
+        } catch (parseError) {
+          throw new Error('Invalid JSON response from server');
+        }
+      })
+      .then(({ audio: audioBase64, contentType }) => {
+        if (!audioBase64) {
+          throw new Error('Invalid audio response from server');
+        }
+
+        const binary = window.atob(audioBase64);
+        const len = binary.length;
+        const bytes = new Uint8Array(len);
+        for (let i = 0; i < len; i += 1) {
+          bytes[i] = binary.charCodeAt(i);
+        }
+
+        const blob = new Blob([bytes.buffer], { type: contentType || 'audio/mpeg' });
         const url = URL.createObjectURL(blob);
         const newAudio = new Audio(url);
         newAudio.onended = () => {
           setIsPlaying(false);
           setAudio(null);
+          URL.revokeObjectURL(url);
         };
         setAudio(newAudio);
-        newAudio.play();
-        setIsPlaying(true);
-      }
-    });
+        newAudio.play()
+          .then(() => {
+            setIsPlaying(true);
+          })
+          .catch((playError) => {
+            setError(playError.message);
+            setIsPlaying(false);
+            setAudio(null);
+            URL.revokeObjectURL(url);
+          });
+      })
+      .catch((fetchError) => {
+        console.error(fetchError);
+        setError(fetchError.message);
+        setIsPlaying(false);
+      });
   };
 
   return (
@@ -74,6 +121,11 @@ const StoryPlayer = ({ story }) => {
       <button onClick={handlePlayPause}>
         {isPlaying ? 'Pause' : 'Play'}
       </button>
+      {error && (
+        <p style={{ color: 'red' }}>
+          {error}
+        </p>
+      )}
     </div>
   );
 };

--- a/server/index.js
+++ b/server/index.js
@@ -1,0 +1,55 @@
+require('dotenv').config();
+const express = require('express');
+const AWS = require('aws-sdk');
+
+const app = express();
+const port = process.env.PORT || 5000;
+
+app.use(express.json());
+
+const polly = new AWS.Polly({
+  region: process.env.AWS_REGION || 'us-east-1'
+});
+
+app.post('/api/polly', async (req, res) => {
+  const { text, voiceId = 'Joanna', outputFormat = 'mp3' } = req.body || {};
+
+  if (!text) {
+    return res.status(400).json({ error: 'Text is required' });
+  }
+
+  try {
+    const params = {
+      Text: text,
+      VoiceId: voiceId,
+      OutputFormat: outputFormat
+    };
+
+    const { AudioStream, ContentType } = await polly.synthesizeSpeech(params).promise();
+
+    if (!AudioStream) {
+      return res.status(500).json({ error: 'No audio stream returned by Polly' });
+    }
+
+    const audioBase64 = AudioStream.toString('base64');
+
+    return res.json({
+      audio: audioBase64,
+      contentType: ContentType || 'audio/mpeg'
+    });
+  } catch (error) {
+    console.error('Polly synthesis failed', error);
+    return res.status(500).json({ error: 'Failed to synthesize speech' });
+  }
+});
+
+app.use((err, req, res, next) => {
+  console.error('Unhandled server error', err);
+  res.status(500).json({ error: 'Internal server error' });
+});
+
+app.listen(port, () => {
+  console.log(`Server listening on port ${port}`);
+});
+
+module.exports = app;

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "kidcoachai-server",
+  "version": "1.0.0",
+  "description": "Express server for AWS Polly integration",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "aws-sdk": "^2.1493.0",
+    "dotenv": "^16.4.5",
+    "express": "^4.19.2"
+  }
+}


### PR DESCRIPTION
## Summary
- replace the client-side AWS SDK usage in StoryPlayer with a fetch call to a backend endpoint and surface playback errors to the UI
- add a lightweight Express server that proxies `/api/polly` requests to Amazon Polly using environment credentials
- document the required environment variables and how to start the backend in the project README

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dc7f47edd0832baf8ff9b54d8ab3bc